### PR TITLE
Enable C++11 support in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ def pkg_config_version(package):
         sys.stderr.write("Can't determine version of %s\n" % package)
 
 ext_args = {}
+ext_args['extra_compile_args'] = ['-std=c++11']
 pkg_config('poppler-qt5', ext_args)
 
 if 'libraries' not in ext_args:


### PR DESCRIPTION
Compiling for QT5 requires that C++11 support is enabled in the C++ compiler. In GCC 4.8.1+, C++11 support is available but disabled by default for versions below 6.0. This change would ensure that C++11 support is enabled for those compilers.

Closes #13.