### PR TITLE
use PyList_SetItem instead of PyList_SET_ITEM for comparison

### DIFF
--- a/types.sip
+++ b/types.sip
@@ -27,7 +27,7 @@
     foreach (Poppler::Document::RenderBackend value, set)
     {
         PyObject *obj = PyLong_FromLong ((long) value);
-        if (obj == NULL || PyList_SET_ITEM (l, i, obj) < 0)
+        if (obj == NULL || PyList_SetItem(l, i, obj) < 0)
         {
             Py_DECREF(l);
 


### PR DESCRIPTION
see https://github.com/wbsoft/python-poppler-qt4/issues/17,
https://github.com/wbsoft/python-poppler-qt4/pull/18,
https://github.com/macports/macports-ports/pull/1064,
and https://trac.macports.org/ticket/55014#comment:7