### PR TITLE
Update Poppler Qt5 link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Documentation
 -------------
 
 The Python API closely follows the Poppler Qt5 C++ interface library API,
-documented at http://people.freedesktop.org/~aacid/docs/qt5/ .
+documented at https://poppler.freedesktop.org/api/qt5/ .
 
 Note: Releases of PyQt5 < 5.4 currently do not support the QtXml module,
 all methods that use the QDomDocument, QDomElement and QDomNode types are


### PR DESCRIPTION
API documentation link has changed, pointing to poppler qt5 version 0.85.0 instead of 0.74.0