### PR TITLE
use a keyword known by python 3.6's subprocess.check_output

### DIFF
--- a/project.py
+++ b/project.py
@@ -42,7 +42,7 @@ class PopplerQt5Bindings(PyQtBindings):
     def run_pkg_config(option):
         output = subprocess.check_output(
             ['pkg-config', option, 'poppler-qt5'],
-            text=True)
+            universal_newlines=True)
         return output.rstrip()
 
     def apply_user_defaults(self, tool):


### PR DESCRIPTION
`text` has only been added as an alias for `universal_newlines` in Python 3.7: https://docs.python.org/3/library/subprocess.html#subprocess.check_output

There is no reason not to support Python 3.6 with a sip-build build.