### PR TITLE
map type for FormFieldChoice::choicesWithExportValues()

### DIFF
--- a/types.sip
+++ b/types.sip
@@ -331,5 +331,98 @@ template <TYPE>
 };
 
 
+/**
+ * Convert QVector< QPair<TYPE, TYPE> >
+ * from and to a Python list of a 2-item tuple
+ */
+
+template<TYPE>
+%MappedType QVector< QPair<TYPE, TYPE> >
+{
+%TypeHeaderCode
+#include <qvector.h>
+#include <qpair.h>
+%End
+
+%ConvertFromTypeCode
+  // Create the list.
+  PyObject *l;
+
+  if ((l = PyList_New(sipCpp->size())) == NULL)
+      return NULL;
+
+  // Set the list elements.
+  for (int i = 0; i < sipCpp->size(); ++i)
+  {
+    QPair<TYPE, TYPE>* p = new QPair<TYPE, TYPE>(sipCpp->at(i));
+    PyObject *ptuple = PyTuple_New(2);
+    PyObject *pfirst;
+    PyObject *psecond;
+
+    TYPE *sfirst = new TYPE(p->first);
+    if ((pfirst = sipConvertFromType(sfirst, sipType_TYPE, sipTransferObj)) == NULL)
+    {
+      Py_DECREF(l);
+      Py_DECREF(ptuple);
+      return NULL;
+    }
+    PyTuple_SET_ITEM(ptuple, 0, pfirst);
+
+    TYPE *ssecond = new TYPE(p->second);
+    if ((psecond = sipConvertFromType(ssecond, sipType_TYPE, sipTransferObj)) == NULL)
+    {
+      Py_DECREF(l);
+      Py_DECREF(ptuple);
+      Py_DECREF(pfirst);
+      return NULL;
+    }
+    PyTuple_SET_ITEM(ptuple, 1, psecond);
+
+    PyList_SET_ITEM(l, i, ptuple);
+  }
+
+  return l;
+%End
+
+%ConvertToTypeCode
+  const sipTypeDef* qpair_type = sipFindType("QPair<TYPE, TYPE>");
+
+  // Check the type if that is all that is required.
+  if (sipIsErr == NULL)
+  {
+    if (!PySequence_Check(sipPy))
+      return 0;
+
+    for (int i = 0; i < PySequence_Size(sipPy); ++i)
+      if (!sipCanConvertToType(PySequence_ITEM(sipPy, i), qpair_type, SIP_NOT_NONE))
+        return 0;
+
+    return 1;
+  }
+
+
+  QVector< QPair<TYPE, TYPE> > *qv = new QVector< QPair<TYPE, TYPE> >;
+
+  for (int i = 0; i < PySequence_Size(sipPy); ++i)
+  {
+    int state;
+    QPair<TYPE, TYPE> * p = reinterpret_cast< QPair<TYPE, TYPE> * >(sipConvertToType(PySequence_ITEM(sipPy, i), qpair_type, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
+
+    if (*sipIsErr)
+    {
+      sipReleaseType(p, qpair_type, state);
+      delete qv;
+      return 0;
+    }
+    qv->append(*p);
+    sipReleaseType(p, qpair_type, state);
+  }
+
+  *sipCppPtr = qv;
+  return sipGetState(sipTransferObj);
+%End
+
+};
+
 
 /* kate: indent-width 4; space-indent on; hl c++; indent-mode cstyle; */


### PR DESCRIPTION
Fixes #43 

[formfieldchoice.pdf](https://github.com/frescobaldi/python-poppler-qt5/files/6030591/formfieldchoice.pdf) made with LibreOffice.
```python
from pprint import pprint
from popplerqt5 import Poppler as poppler
P = poppler.Document.load('formfieldchoice.pdf')
fields = P[0].formFields()
for f in fields:
    print(f.name())
    pprint(f.choicesWithExportValues())
```

```
Listfield 1
[('l1', 'l1'), ('l2', 'l2'), ('l3', 'l3')]
Combobox 1
[('Combo Item 1', 'Combo Item 1'),
 ('Combo Item 2', 'Combo Item 2'),
 ('Combo Item a third one', 'Combo Item a third one')]
Empty List Field
[]
```


*(I have no easy access to Acrobat Professional or do not know how to create a PDF Form with a different export value than the field text value)*